### PR TITLE
Fix Crash on OSX < 10.11

### DIFF
--- a/src/Popup/PanelController.m
+++ b/src/Popup/PanelController.m
@@ -24,7 +24,7 @@
 @property (nonatomic, retain) NSTimer *deviceUpdateTimer;
 @property (nonatomic, retain) PreferenceController *controllerWindow;
 @property (nonatomic, retain) AudioDeviceController *audioController;
-@property (nonatomic, strong) CABTLEMIDIWindowController *blueDeviceView;
+@property (nonatomic, strong) NSWindowController *blueDeviceView;
 
 @end
 


### PR DESCRIPTION
We should weakly link against 10.11 to solve this crash.

https://github.com/sieren/midimittrusb/issues/4
