### PR TITLE
WIP - Re-initialize AudioController before view

### DIFF
--- a/src/Popup/PanelController.m
+++ b/src/Popup/PanelController.m
@@ -92,10 +92,7 @@
 
 -(IBAction)iosAudioDeviceBrowser:(id)sender
 {
-  if (self.audioController == nil) {
-    self.audioController = [[AudioDeviceController alloc] init];
-  }
-  
+  self.audioController = [[AudioDeviceController alloc] init];
   [audioController showWindow:self];
 }
 


### PR DESCRIPTION
This works around an issue on OSX Sierra where
the iOS Audio Controller would not show on subsequent calls.